### PR TITLE
Fixes type issue with bytes type in json.loads

### DIFF
--- a/pypaytabs/Paytabs.py
+++ b/pypaytabs/Paytabs.py
@@ -36,7 +36,7 @@ class Paytabs(object):
         return self._parse_response(result)
 
     def _parse_response(self, data):
-        json_dict = json.loads(data, encoding='utf-8')
+        json_dict = json.loads(data.decode('utf-8'), encoding='utf-8')
         is_error = int(json_dict['response_code']) in ERROR_CODES
         if is_error:
             raise PaytabsApiError(json_dict['response_code'], json_dict['result'])


### PR DESCRIPTION
This fixes a TypeError seen when using pypaytabs on Python 3.5.
`http.client.HTTPResponse.read()` returns an object of type `bytes`, which `json.loads` cannot load.
This PR just decodes the response to correctly decode the bytes object and deserialize the json results.

Logs from issue fixed here:
```
File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.5/site-packages/pypaytabs/Paytabs.py" in authenticate
  28.         return self._parse_response(result)

File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.5/site-packages/pypaytabs/Paytabs.py" in _parse_response
  39.         json_dict = json.loads(data, encoding='utf-8')

File "/usr/lib/python3.5/json/__init__.py" in loads
  312.                             s.__class__.__name__))

Exception Type: TypeError at /api/v2/checkout/
Exception Value: the JSON object must be str, not 'bytes'
```